### PR TITLE
deps: Upgrade snakeyaml to fix CVE-2022-1471

### DIFF
--- a/pulsar-snowflake-connector/pom.xml
+++ b/pulsar-snowflake-connector/pom.xml
@@ -58,6 +58,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>2.0</version>
+    </dependency>
+    <dependency>
       <groupId>${pulsar.distribution-name}</groupId>
       <artifactId>pulsar-io-core</artifactId>
       <version>${pulsar.version}</version>
@@ -102,6 +107,12 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.snowflake</groupId>
+      <artifactId>snowflake-kafka-connector</artifactId>
+      <version>1.7.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### Motivation
To fix critical vulnerability CVE-2022-1471
http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-1471
### Modification

- update version of snakeyaml: from 1.32 to 2.0
- Included snowflake-kafka-connector dependency in test scope, as tests were failing otherwise.