### PR TITLE
deps: Upgrade snowflake-kafka-connector to fix Vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <shadePluginPhase>package</shadePluginPhase>
     <narPluginPhase>package</narPluginPhase>
     <pulsar.version>2.10.4.3</pulsar.version>
-    <snowflakeconnector.version>1.9.2</snowflakeconnector.version>
+    <snowflakeconnector.version>1.9.4</snowflakeconnector.version>
     <avro.version>1.10.2</avro.version>
     <mockito.version>3.8.0</mockito.version>
     <!-- Plugin dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-    <test.additional.args />
+    <test.additional.args/>
     <testReuseFork>true</testReuseFork>
     <testForkCount>4</testForkCount>
     <testRetryCount>1</testRetryCount>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <shadePluginPhase>package</shadePluginPhase>
     <narPluginPhase>package</narPluginPhase>
     <pulsar.version>2.10.4.3</pulsar.version>
-    <snowflakeconnector.version>1.7.2</snowflakeconnector.version>
+    <snowflakeconnector.version>1.9.2</snowflakeconnector.version>
     <avro.version>1.10.2</avro.version>
     <mockito.version>3.8.0</mockito.version>
     <!-- Plugin dependencies -->

--- a/pulsar-snowflake-connector/pom.xml
+++ b/pulsar-snowflake-connector/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>com.snowflake</groupId>
       <artifactId>snowflake-kafka-connector</artifactId>
-      <version>1.7.2</version>
+      <version>1.9.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pulsar-snowflake-connector/pom.xml
+++ b/pulsar-snowflake-connector/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>com.snowflake</groupId>
       <artifactId>snowflake-kafka-connector</artifactId>
-      <version>1.9.4</version>
+      <version>${snowflakeconnector.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pulsar-snowflake-connector/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorMock.java
+++ b/pulsar-snowflake-connector/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorMock.java
@@ -17,28 +17,28 @@ package com.snowflake.kafka.connector;
 
 import static org.mockito.Mockito.when;
 
-import com.snowflake.kafka.connector.internal.Logging;
+import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
-import com.snowflake.kafka.connector.internal.SnowflakeTelemetryService;
+import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.mockito.Mockito;
 
-@Slf4j
 public class SnowflakeSinkConnectorMock extends SnowflakeSinkConnector {
 
+  private KCLogger DYNAMIC_LOGGER;
   final SnowflakeSinkConnector wrapped;
   final SnowflakeConnectionService connMock;
   final SnowflakeTelemetryService telemetryMock;
 
   public SnowflakeSinkConnectorMock() {
-    log.info("[sf_mock] Creating SnowflakeSinkConnectorMock");
+    DYNAMIC_LOGGER = new KCLogger(this.getClass().getName());
+    this.DYNAMIC_LOGGER.info("[sf_mock] Creating SnowflakeSinkConnectorMock");
     wrapped = new SnowflakeSinkConnector();
     telemetryMock = Mockito.mock(SnowflakeTelemetryService.class);
     connMock = Mockito.mock(SnowflakeConnectionService.class);
@@ -74,7 +74,7 @@ public class SnowflakeSinkConnectorMock extends SnowflakeSinkConnector {
   @Override
   public void start(Map<String, String> parsedConfig) {
     Utils.checkConnectorVersion();
-    log.info(Logging.logMessage("SnowflakeSinkConnector:start"));
+    this.DYNAMIC_LOGGER.info("SnowflakeSinkConnector:start");
 
     FieldUtils.writeDeclaredField(wrapped, "setupComplete", false, true);
     FieldUtils.writeDeclaredField(wrapped, "connectorStartTime", System.currentTimeMillis(), true);

--- a/snowflake-kafka-connector-shaded/pom.xml
+++ b/snowflake-kafka-connector-shaded/pom.xml
@@ -72,8 +72,8 @@
             </relocation>
           </relocations>
           <transformers>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-            <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer" />
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer"/>
           </transformers>
         </configuration>
       </plugin>


### PR DESCRIPTION
### Motivation
To fix vulnerability on Guava : CVE-2023-2976, CVE-2020-8908
com.snowflake:snowflake-kafka-connector@1.7.2 has a dependency on 
-> com.google.guava:guava@31.0.1-jre which has the vulnerabilities

### Modification
- Update snowflake-kafka-connector: from 1.7.2 to 1.9.4
