### PR TITLE
Upgrade Avro to 1.11.4 to address CVE-2024-47561

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <narPluginPhase>package</narPluginPhase>
     <pulsar.version>2.10.4.3</pulsar.version>
     <snowflakeconnector.version>1.9.4</snowflakeconnector.version>
-    <avro.version>1.10.2</avro.version>
+    <avro.version>1.11.4</avro.version>
     <mockito.version>3.8.0</mockito.version>
     <!-- Plugin dependencies -->
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>


### PR DESCRIPTION
# Motivation

Avro 1.11.3 contains critical 9.3/10 level RCE vulnerability in Avro Java SDK <1.11.4, [CVE-2024-47561](https://github.com/advisories/GHSA-r7pg-v2c8-mfg3)>