### PR TITLE
deps: Update dependency to fix CVE-2024-36114 & CVE-2024-53990

### DIFF
--- a/.github/workflows/ci-base.yaml
+++ b/.github/workflows/ci-base.yaml
@@ -24,7 +24,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -104,15 +104,19 @@
         <artifactId>avro</artifactId>
         <version>${avro.version}</version>
       </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
         <version>${aircompressor.version}</version>
+        <scope>runtime</scope>
       </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
       <dependency>
         <groupId>org.asynchttpclient</groupId>
         <artifactId>async-http-client</artifactId>
         <version>${asynchttpclient.version}</version>
+        <scope>runtime</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,8 @@
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
     <dependency-check-maven.version>8.0.1</dependency-check-maven.version>
+    <asynchttpclient.version>2.12.4</asynchttpclient.version>
+    <aircompressor.version>0.27</aircompressor.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -101,6 +103,16 @@
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
         <version>${avro.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.airlift</groupId>
+        <artifactId>aircompressor</artifactId>
+        <version>${aircompressor.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.asynchttpclient</groupId>
+        <artifactId>async-http-client</artifactId>
+        <version>${asynchttpclient.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
asynchttpclient 2.12.1 contains CVE-2024-53990 vulnerability and its fixed in 2.12.4.
aircompressor 0.21 contains CVE-2024-36114 vulnerability and its fixed in 0.27